### PR TITLE
Include LICENSE.txt file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE.txt
 recursive-include src VERSION
 graft src
 global-exclude *.pyc


### PR DESCRIPTION
Ensure that the license file is part of the source tarball published on PyPI.

It would be nice if you could create a new release after merging because some distributions require to ship the license file, e. g. Fedora. Thanks