### PR TITLE
Remove deprecated urllib3 secure extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "requests>=2.0",
-        "urllib3[secure]"
+        "urllib3"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
`urllib3[secure]` has been deprecated and will be removed in the future.
AFAICT the secure extra isn't used anywhere, so it's safe to remove it.

More details
- https://github.com/urllib3/urllib3/issues/2680